### PR TITLE
ci: add workflows to deploy containers to Azure

### DIFF
--- a/.github/workflows/deploy-opptak-backend.yml
+++ b/.github/workflows/deploy-opptak-backend.yml
@@ -1,0 +1,29 @@
+name: Deploy opptak backend container to Azure
+
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - frontend/**
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: azure/docker-login@v1
+      with:
+        login-server: ntnuiopptak.azurecr.io
+        username: ${{ secrets.REGISTRY_USERNAME }}
+        password: ${{ secrets.REGISTRY_PASSWORD }}
+
+    - run: |
+        docker build ./backend -t ntnuiopptak.azurecr.io/opptak-backend:latest
+        docker push ntnuiopptak.azurecr.io/opptak-backend:latest
+    - uses: azure/webapps-deploy@v2
+      with:
+        app-name: 'ntnuiopptak-backend'
+        publish-profile: ${{ secrets.OPPTAK_BACKEND_AZURE_PUBLISH_PROFILE }}
+        images: 'ntnuiopptak.azurecr.io/opptak-backend:latest'

--- a/.github/workflows/deploy-opptak-backend.yml
+++ b/.github/workflows/deploy-opptak-backend.yml
@@ -1,29 +1,29 @@
 name: Deploy opptak backend container to Azure
 
 on:
-  push:
-    branches:
-      - master
-    paths-ignore:
-      - frontend/**
+ push:
+  branches:
+   - master
+  paths-ignore:
+   - frontend/**
 jobs:
-  build:
-    runs-on: ubuntu-latest
+ build:
+  runs-on: ubuntu-latest
 
-    steps:
-    - uses: actions/checkout@v3
+  steps:
+   - uses: actions/checkout@v3
 
-    - uses: azure/docker-login@v1
-      with:
-        login-server: ntnuiopptak.azurecr.io
-        username: ${{ secrets.REGISTRY_USERNAME }}
-        password: ${{ secrets.REGISTRY_PASSWORD }}
+   - uses: azure/docker-login@v1
+     with:
+      login-server: ntnuiopptak.azurecr.io
+      username: ${{ secrets.REGISTRY_USERNAME }}
+      password: ${{ secrets.REGISTRY_PASSWORD }}
 
-    - run: |
-        docker build ./backend -t ntnuiopptak.azurecr.io/opptak-backend:latest
-        docker push ntnuiopptak.azurecr.io/opptak-backend:latest
-    - uses: azure/webapps-deploy@v2
-      with:
-        app-name: 'ntnuiopptak-backend'
-        publish-profile: ${{ secrets.OPPTAK_BACKEND_AZURE_PUBLISH_PROFILE }}
-        images: 'ntnuiopptak.azurecr.io/opptak-backend:latest'
+   - run: |
+      docker build ./backend -t ntnuiopptak.azurecr.io/opptak-backend:latest
+      docker push ntnuiopptak.azurecr.io/opptak-backend:latest
+   - uses: azure/webapps-deploy@v2
+     with:
+      app-name: 'ntnuiopptak-backend'
+      publish-profile: ${{ secrets.OPPTAK_BACKEND_AZURE_PUBLISH_PROFILE }}
+      images: 'ntnuiopptak.azurecr.io/opptak-backend:latest'

--- a/.github/workflows/deploy-opptak-frontend.yml
+++ b/.github/workflows/deploy-opptak-frontend.yml
@@ -1,0 +1,29 @@
+name: Deploy opptak frontend container to Azure
+
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - backend/**
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: azure/docker-login@v1
+      with:
+        login-server: ntnuiopptak.azurecr.io
+        username: ${{ secrets.REGISTRY_USERNAME }}
+        password: ${{ secrets.REGISTRY_PASSWORD }}
+
+    - run: |
+        docker build ./frontend -f frontend/Dockerfile.prod -t ntnuiopptak.azurecr.io/opptak-frontend:latest
+        docker push ntnuiopptak.azurecr.io/opptak-frontend:latest
+    - uses: azure/webapps-deploy@v2
+      with:
+        app-name: 'ntnuiopptak-frontend'
+        publish-profile: ${{ secrets.OPPTAK_FRONTEND_AZURE_PUBLISH_PROFILE }}
+        images: 'ntnuiopptak.azurecr.io/opptak-frontend:latest'

--- a/.github/workflows/deploy-opptak-frontend.yml
+++ b/.github/workflows/deploy-opptak-frontend.yml
@@ -1,29 +1,29 @@
 name: Deploy opptak frontend container to Azure
 
 on:
-  push:
-    branches:
-      - master
-    paths-ignore:
-      - backend/**
+ push:
+  branches:
+   - master
+  paths-ignore:
+   - backend/**
 jobs:
-  build:
-    runs-on: ubuntu-latest
+ build:
+  runs-on: ubuntu-latest
 
-    steps:
-    - uses: actions/checkout@v3
+  steps:
+   - uses: actions/checkout@v3
 
-    - uses: azure/docker-login@v1
-      with:
-        login-server: ntnuiopptak.azurecr.io
-        username: ${{ secrets.REGISTRY_USERNAME }}
-        password: ${{ secrets.REGISTRY_PASSWORD }}
+   - uses: azure/docker-login@v1
+     with:
+      login-server: ntnuiopptak.azurecr.io
+      username: ${{ secrets.REGISTRY_USERNAME }}
+      password: ${{ secrets.REGISTRY_PASSWORD }}
 
-    - run: |
-        docker build ./frontend -f frontend/Dockerfile.prod -t ntnuiopptak.azurecr.io/opptak-frontend:latest
-        docker push ntnuiopptak.azurecr.io/opptak-frontend:latest
-    - uses: azure/webapps-deploy@v2
-      with:
-        app-name: 'ntnuiopptak-frontend'
-        publish-profile: ${{ secrets.OPPTAK_FRONTEND_AZURE_PUBLISH_PROFILE }}
-        images: 'ntnuiopptak.azurecr.io/opptak-frontend:latest'
+   - run: |
+      docker build ./frontend -f frontend/Dockerfile.prod -t ntnuiopptak.azurecr.io/opptak-frontend:latest
+      docker push ntnuiopptak.azurecr.io/opptak-frontend:latest
+   - uses: azure/webapps-deploy@v2
+     with:
+      app-name: 'ntnuiopptak-frontend'
+      publish-profile: ${{ secrets.OPPTAK_FRONTEND_AZURE_PUBLISH_PROFILE }}
+      images: 'ntnuiopptak.azurecr.io/opptak-frontend:latest'


### PR DESCRIPTION
Closes #90 

## Summary of changes

Automatically build and send frontend and backend docker images to our Azure container registry depending on changes in the repository, then enable the new image in the web app.
