### PR TITLE
refactor: use slug instead of name

### DIFF
--- a/backend/controllers/applicationController.ts
+++ b/backend/controllers/applicationController.ts
@@ -58,7 +58,7 @@ const getApplicationById = async (
 			.populate<IPopulatedApplicationCommittees>('committees', 'name slug')
 			.populate({
 				path: 'statuses',
-				populate: { path: 'committee', model: 'Committee', select: 'name' },
+				populate: { path: 'committee', model: 'Committee', select: 'name slug' },
 				select: '-__v',
 			})
 			.then((applicationRes) => applicationRes)

--- a/frontend/src/pages/ApplicationDetails.tsx
+++ b/frontend/src/pages/ApplicationDetails.tsx
@@ -283,7 +283,7 @@ function ApplicationDetailPage() {
 		const statByRel = statuses
 			.map((status) => {
 				// If the status can be edited by the user, it should be shown on the top
-				const isStatusForMainBoard = status.committee.name === 'Hovedstyret'
+				const isStatusForMainBoard = status.committee.slug === 'hovedstyret'
 				if (
 					userCommitteeIds.includes(status.committee._id) ||
 					(isUserInElectionCommittee && isStatusForMainBoard)

--- a/frontend/src/types/types.tsx
+++ b/frontend/src/types/types.tsx
@@ -6,6 +6,7 @@ export interface IStatus {
 	set_by: string | null
 	committee: {
 		name: string
+		slug: string
 		_id: number
 	}
 	updated_date: Date


### PR DESCRIPTION
## Summary of changes

Fixes the issue with name changes of committees as long as slug is the same as before.