### PR TITLE
feat: show open committees on top of multiselect

### DIFF
--- a/frontend/src/components/ApplicationForm.tsx
+++ b/frontend/src/components/ApplicationForm.tsx
@@ -165,6 +165,15 @@ export function Form({ committees }: IFormProps) {
 				}
 				return 0
 			})
+			.sort((a, b) => {
+				if (a.disabled && !b.disabled) {
+					return 1
+				}
+				if (!a.disabled && b.disabled) {
+					return -1
+				}
+				return 0
+			})
 	}
 
 	const form = useForm({


### PR DESCRIPTION
Closes #135 

## Summary of changes

* Committees that are currently closed for applications are shown at the bottom of the multiselect on the application form

<img width="493" alt="image" src="https://user-images.githubusercontent.com/54808860/212305456-20a33092-31a5-4e9a-83e0-0affa1244f49.png">
