### PR TITLE
feat: change main board name based on season

### DIFF
--- a/frontend/src/components/ApplicationForm.tsx
+++ b/frontend/src/components/ApplicationForm.tsx
@@ -13,7 +13,7 @@ import { useEffect, useState } from 'react'
 import { showNotification, updateNotification } from '@mantine/notifications'
 import { Check, ChevronDown, X } from 'tabler-icons-react'
 import { ICommittee } from '../types/types'
-import { REACT_APP_MAIN_BOARD_ID } from '../utils/constants'
+import { MAIN_BOARD_NAME, REACT_APP_MAIN_BOARD_ID } from '../utils/constants'
 
 interface ISubmissionApplication {
 	email: string
@@ -148,7 +148,7 @@ export function Form({ committees }: IFormProps) {
 			})
 			.map((committee: ICommittee) => {
 				if (committee.slug === 'hovedstyret') {
-					committee.name = new Date().getMonth() < 6 ? 'Hovedstyret' : 'Introstyret'
+					committee.name = MAIN_BOARD_NAME
 				}
 				return committee
 			})
@@ -296,9 +296,7 @@ export function Form({ committees }: IFormProps) {
 						error: classes.textareaError,
 					}}
 					description='Nevn gjerne alder, klasse, studieretning, erfaring og motivasjon'
-					label={`Søknadstekst for ${
-						new Date().getMonth() < 6 ? 'Hovedstyret' : 'Introstyret'
-					}`}
+					label={`Søknadstekst for ${MAIN_BOARD_NAME}`}
 					autosize
 					maxRows={10}
 					minRows={3}

--- a/frontend/src/components/ApplicationForm.tsx
+++ b/frontend/src/components/ApplicationForm.tsx
@@ -147,6 +147,12 @@ export function Form({ committees }: IFormProps) {
 				return committee.slug !== 'valgkomiteen'
 			})
 			.map((committee: ICommittee) => {
+				if (committee.slug === 'hovedstyret') {
+					committee.name = new Date().getMonth() < 6 ? 'Hovedstyret' : 'Introstyret'
+				}
+				return committee
+			})
+			.map((committee: ICommittee) => {
 				if (!committee.accepts_admissions) {
 					return {
 						value: committee._id.toString(),
@@ -290,7 +296,9 @@ export function Form({ committees }: IFormProps) {
 						error: classes.textareaError,
 					}}
 					description='Nevn gjerne alder, klasse, studieretning, erfaring og motivasjon'
-					label='Søknadstekst for Introstyret'
+					label={`Søknadstekst for ${
+						new Date().getMonth() < 6 ? 'Hovedstyret' : 'Introstyret'
+					}`}
 					autosize
 					maxRows={10}
 					minRows={3}

--- a/frontend/src/pages/ApplicationDetails.tsx
+++ b/frontend/src/pages/ApplicationDetails.tsx
@@ -18,7 +18,7 @@ import StatusInput from '../components/StatusInput'
 import { getApplication } from '../services/Applications'
 import { getUserCommittees, IRoleInCommittee } from '../services/Committees'
 import { IApplication, IPopulatedStatus } from '../types/types'
-import { REACT_APP_MAIN_BOARD_ID } from '../utils/constants'
+import { MAIN_BOARD_NAME, REACT_APP_MAIN_BOARD_ID } from '../utils/constants'
 
 interface IStatusesStyleProps {
 	amountOfStatuses: number
@@ -423,8 +423,7 @@ function ApplicationDetailPage() {
 							{!isLoading && application && isToMainBoard && (
 								<Box className={classes.applicationTextItem}>
 									<h2 className={classes.sectionTitle}>
-										<AlignJustified size={32} /> Søknadstekst til{' '}
-										{`${new Date().getMonth() < 6 ? 'Hovedstyret' : 'Introstyret'}`}
+										<AlignJustified size={32} /> Søknadstekst til {`${MAIN_BOARD_NAME}`}
 									</h2>
 									{!application.main_board_text.length ? (
 										<i>Ingen søknadstekst</i>

--- a/frontend/src/pages/ApplicationDetails.tsx
+++ b/frontend/src/pages/ApplicationDetails.tsx
@@ -423,7 +423,8 @@ function ApplicationDetailPage() {
 							{!isLoading && application && isToMainBoard && (
 								<Box className={classes.applicationTextItem}>
 									<h2 className={classes.sectionTitle}>
-										<AlignJustified size={32} /> Søknadstekst til Introstyret
+										<AlignJustified size={32} /> Søknadstekst til{' '}
+										{`${new Date().getMonth() < 6 ? 'Hovedstyret' : 'Introstyret'}`}
 									</h2>
 									{!application.main_board_text.length ? (
 										<i>Ingen søknadstekst</i>

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -3,3 +3,6 @@ export const REACT_APP_MAIN_BOARD_ID =
 
 export const REACT_APP_ELECTION_COMMITTEE_ID =
 	Number(process.env.REACT_APP_ELECTION_COMMITTEE_ID) || 53
+
+export const MAIN_BOARD_NAME =
+	new Date().getMonth() < 6 ? 'Hovedstyret' : 'Introstyret'


### PR DESCRIPTION
Closes #151 

This is a very manual and not really scalable or sustainable way of resolving the naming-issue. Thoughts? 

## Summary of changes

* "Hovedstyret" in spring
* "Introstyret" in autumn
