### PR TITLE
feat: automatic selection in filter

### DIFF
--- a/frontend/src/components/ApplicationItem.tsx
+++ b/frontend/src/components/ApplicationItem.tsx
@@ -189,7 +189,8 @@ function ApplicationItem({
 				<a href={`tel:${phone_number}`}>{phone_number}</a>
 			</div>
 			<div className={classes.statusDiv}>
-				{chosenCommittees.length === 1 ? (
+				{chosenCommittees.length === 1 &&
+				chosenCommittees[0].toString().length > 0 ? (
 					statuses
 						.filter((status) => status.committee === Number(chosenCommittees[0]))
 						.map((status) => (

--- a/frontend/src/components/FilterSearch.tsx
+++ b/frontend/src/components/FilterSearch.tsx
@@ -6,9 +6,10 @@ import {
 	TextInput,
 } from '@mantine/core'
 import debounce from 'lodash.debounce'
-import { useMemo } from 'react'
+import { useContext, useMemo } from 'react'
 import { forwardRef, useEffect, useState } from 'react'
 import { ChevronDown, Menu2, Search } from 'tabler-icons-react'
+import { UserContext } from '../pages/ApplicationOverview'
 import { getAllCommittees } from '../services/Committees'
 import { ICommittee } from '../types/types'
 import { StatusTypes } from '../utils/enums'
@@ -143,6 +144,7 @@ function FilterSearch({
 }: FilterSearchProps) {
 	const { classes } = useStyles()
 	const [committees, setCommittees] = useState<ICommittee[]>([])
+	const { isInElectionCommittee, isInMainBoard } = useContext(UserContext)
 
 	useEffect(() => {
 		// Retrieve committees for multiselect
@@ -198,6 +200,7 @@ function FilterSearch({
 		committees.forEach((committee: ICommittee) => {
 			dataList.push({ value: `${committee._id}`, label: committee.name })
 		})
+		dataList.sort((a, b) => a.label.localeCompare(b.label))
 		return dataList
 	}
 
@@ -280,23 +283,43 @@ function FilterSearch({
 					rightSection={<ChevronDown size={14} />}
 					rightSectionWidth={40}
 				/>
-				<MultiSelect
-					classNames={{
-						root: classes.multiselectRoot,
-						input: classes.multiselectInput,
-						value: classes.multiselectValue,
-					}}
-					data={mapCommitteesToMultiselectData()}
-					label={<span className={classes.badgeLabel}>Velg utvalg</span>}
-					placeholder='Velg utvalg'
-					searchable
-					clearable
-					nothingFound='Nothing found'
-					defaultValue={chosenCommittees}
-					value={chosenCommittees}
-					onChange={setChosenCommittees}
-					rightSectionWidth={40}
-				/>
+				{isInElectionCommittee || isInMainBoard ? (
+					<MultiSelect
+						classNames={{
+							root: classes.multiselectRoot,
+							input: classes.multiselectInput,
+							value: classes.multiselectValue,
+						}}
+						data={mapCommitteesToMultiselectData()}
+						label={<span className={classes.badgeLabel}>Velg utvalg</span>}
+						placeholder='Velg utvalg'
+						searchable
+						clearable
+						nothingFound='Nothing found'
+						defaultValue={chosenCommittees}
+						value={chosenCommittees}
+						onChange={setChosenCommittees}
+						rightSectionWidth={40}
+					/>
+				) : (
+					<Select
+						classNames={{
+							root: classes.multiselectRoot,
+							label: classes.selectLabel,
+							input: classes.selectInput,
+							rightSection: classes.selectRightSection,
+						}}
+						data={[{ value: '', label: 'Alle' }].concat(
+							mapCommitteesToMultiselectData()
+						)}
+						label={<span className={classes.badgeLabel}>Velg utvalg</span>}
+						defaultValue={chosenCommittees[0]}
+						value={chosenCommittees[0]}
+						onChange={(val) => setChosenCommittees([val as string])}
+						rightSection={<ChevronDown size={14} />}
+						rightSectionWidth={40}
+					/>
+				)}
 			</div>
 		</div>
 	)


### PR DESCRIPTION
Closes #150 

Saves users from clicks and improves visibility of the status-select on the overview implemented in #149, since it appears only if the user is filtering on one committee at a time.

## Summary of changes ✨ 

* Simple select component for normal users
* Multiselect component for election and main committee
* If the user is only part of one committee and no filter is stored, automatically load their committee to the filter
