### PR TITLE
feat: makefile for backend and option to start without loading fixtures

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,0 +1,11 @@
+#---- COMMANDS ----#
+
+start: ##@Docker (start)
+	docker compose up --build
+
+fresh: ##@Docker (start) with fresh fixtures
+	docker compose --profile fresh down
+	docker compose --profile fresh up --build
+
+down: ##@Docker (stop) Stops and removes all containers
+	docker compose --profile fresh down

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -7,5 +7,5 @@ fresh: ##@Docker (start) with fresh fixtures
 	docker compose --profile fresh down
 	docker compose --profile fresh up --build
 
-down: ##@Docker (stop) Stops and removes all containers
-	docker compose --profile fresh down
+clean: ##@Docker (stop) Stops and removes all containers and volumes
+	docker compose --profile fresh down -v

--- a/backend/README.md
+++ b/backend/README.md
@@ -25,7 +25,7 @@ Start the backend and a local database with clean dummy data:
 `make fresh`
 
 Stop and remove backend and local database:  
-`make down`
+`make clean`
 
 ---
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -7,12 +7,29 @@
 - [cors for Express.js](https://github.com/expressjs/cors) - middleware
 - [nodemon](https://github.com/remy/nodemon) - development dependency
 
-## Developement
-
-Install and run the backend using `docker compose up`  
-If you change the fixtures afterwards you have to run `docker compose up --build` to reload the new fixtures to the image.
+## Development
 
 ### Environment variables
 
 Make a copy of `.env.example` and name it `.env`  
 When using docker you don't need to do any modifications for developing locally.
+
+### Start the backend and a database
+
+(Requires docker installed and the environment variables from the step above)
+
+Start the backend and a local database:  
+`make start`
+
+Start the backend and a local database with clean dummy data:  
+`make fresh`
+
+Stop and remove backend and local database:  
+`make down`
+
+---
+
+#### Commands if not using makefile:
+
+Install and run the backend using `docker compose up --build`  
+If you want to populate your local database with dummy data from the fixtures use `docker compose --profile fresh up --build` instead.

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -10,6 +10,7 @@ services:
 
  # Auto imports fixtures, will auto exit when done
  import-fixtures:
+  profiles: ['fresh']
   env_file:
    - .env
   build:


### PR DESCRIPTION
## Summary of changes
Added makefile and possibility to start backend without loading fixtures (similar to medlem)

Instead of using docker command directly for starting the server you can now use "make start" or "make fresh"

Full guide in [readme](https://github.com/NTNUI/opptak/blob/feat/makefile/backend/README.md)