### PR TITLE
revert: remove introstyret fixture

### DIFF
--- a/backend/fixtures/production/committees.json
+++ b/backend/fixtures/production/committees.json
@@ -90,12 +90,5 @@
 		"slug": "materialutvalget",
 		"access_roles": ["deputy_leader"],
 		"accepts_admissions": false
-	},
-	{
-		"_id": 104,
-		"name": "Introstyret",
-		"slug": "introstyret",
-		"access_roles": [],
-		"accepts_admissions": false
 	}
 ]


### PR DESCRIPTION
Introstyret already exists as a rename of hovedstyret, therefore remove duplicate